### PR TITLE
feat: agregar configuración completa del NAT Gateway

### DIFF
--- a/config/roles/natgateway/handlers/main.yml
+++ b/config/roles/natgateway/handlers/main.yml
@@ -1,0 +1,4 @@
+---
+- name: reload nftables
+  ansible.builtin.command: nft -f /etc/nftables.conf
+  changed_when: true

--- a/config/roles/natgateway/tasks/main.yml
+++ b/config/roles/natgateway/tasks/main.yml
@@ -1,0 +1,68 @@
+---
+- name: Habilitar el reenvío de IPs
+  ansible.posix.sysctl:
+    name: net.ipv4.ip_forward
+    value: '1'
+    state: present
+    sysctl_set: yes
+    reload: yes
+
+- name: Asegurar que el reenvío de IP sea persistente
+  ansible.posix.sysctl:
+    name: net.ipv4.ip_forward
+    value: '1'
+    state: present
+    sysctl_file: /etc/sysctl.conf
+    reload: yes
+
+- name: Vaciar las reglas existentes de nftables
+  ansible.builtin.command: nft flush ruleset
+  changed_when: true
+
+- name: Desplegar la configuración de nftables
+  ansible.builtin.template:
+    src: nftables.conf.j2
+    dest: /etc/nftables.conf
+    owner: root
+    group: root
+    mode: '0644'
+  notify: reload nftables
+
+- name: Cargar las reglas de nftables inmediatamente
+  ansible.builtin.command: nft -f /etc/nftables.conf
+  changed_when: true
+
+- name: Configurar los servidores DNS en resolv.conf
+  ansible.builtin.copy:
+    dest: /etc/resolv.conf
+    content: |
+      {% for dns in dns_servers %}
+      nameserver {{ dns }}
+      {% endfor %}
+    owner: root
+    group: root
+    mode: '0644'
+
+- name: Agregar rutas estáticas (en tiempo de ejecución)
+  ansible.builtin.command:
+    cmd: "ip route add {{ item.dest }} via {{ item.via }} dev {{ item.dev }}"
+  loop: "{{ static_routes }}"
+  register: route_result
+  failed_when: route_result.rc != 0 and 'File exists' not in route_result.stderr
+  changed_when: route_result.rc == 0
+
+- name: Asegurar que las rutas estáticas sean persistentes
+  ansible.builtin.blockinfile:
+    path: /etc/network/interfaces
+    block: |
+      # Rutas estáticas para VLAN20 y VLAN30
+      {% for route in static_routes %}
+      up ip route add {{ route.dest }} via {{ route.via }} dev {{ route.dev }}
+      {% endfor %}
+    marker: "# {mark} ANSIBLE MANAGED STATIC ROUTES"
+    create: yes
+    mode: '0644'
+
+- name: Mostrar mensaje de finalización
+  ansible.builtin.debug:
+    msg: "Configuración del Gateway NAT completada en {{ inventory_hostname }}"

--- a/config/roles/natgateway/templates/nftables.conf.j2
+++ b/config/roles/natgateway/templates/nftables.conf.j2
@@ -1,0 +1,59 @@
+table inet filter {
+    chain input {
+        type filter hook input priority filter; policy drop;
+
+        # Loopback
+        iifname "lo" accept
+
+        # Established connections
+        ct state established,related accept
+
+        # SSH from LAN (administration)
+        iifname "{{ external_interface }}" tcp dport 22 ip saddr 192.168.0.0/24 accept
+
+        # SSH from VLANs (ProxyJump hops)
+        tcp dport 22 ip saddr 10.10.0.0/24 accept
+        tcp dport 22 ip saddr 10.20.0.0/24 accept
+        tcp dport 22 ip saddr 10.30.0.0/24 accept
+    }
+
+    chain forward {
+        type filter hook forward priority filter; policy drop;
+
+        # Internal VLAN -> Internet
+        iifname "{{ internal_interface }}" oifname "{{ external_interface }}" ct state established,related,new accept
+
+        # Internet -> Internal VLAN (only response)
+        iifname "{{ external_interface }}" oifname "{{ internal_interface }}" ct state established,related accept
+
+        # Laptop + Jump Host -> VLANs (SSH, Ansible, Terraform)
+        iifname "{{ external_interface }}" ip saddr {
+            192.168.0.250,
+            192.168.0.222
+        } oifname "{{ internal_interface }}" accept
+
+        # VLANs -> Laptop (Harbor access)
+        iifname "{{ internal_interface }}" ip daddr {
+            192.168.0.250,
+            192.168.0.222
+        } accept
+    }
+
+    chain output {
+        type filter hook output priority filter; policy drop;
+
+        oifname "lo" accept
+        ct state established,related,new accept
+    }
+}
+
+table ip nat {
+    chain postrouting {
+        type nat hook postrouting priority srcnat; policy accept;
+
+        {% for subnet in internal_subnets %}
+        # Only NAT traffic going to the internet
+        ip saddr {{ subnet }} oifname "{{ external_interface }}" masquerade
+        {% endfor %}
+    }
+}

--- a/config/roles/natgateway/vars/main.yml
+++ b/config/roles/natgateway/vars/main.yml
@@ -1,0 +1,21 @@
+---
+internal_subnets:
+  - 10.10.0.0/24
+  - 10.20.0.0/24
+  - 10.30.0.0/24
+
+dns_servers:
+  - 1.1.1.1
+  - 9.9.9.9
+  - 208.67.222.222
+
+static_routes:
+  - dest: 10.20.0.0/24
+    via: 10.10.0.254
+    dev: eth1
+  - dest: 10.30.0.0/24
+    via: 10.10.0.254
+    dev: eth1
+
+external_interface: eth0
+internal_interface: eth1


### PR DESCRIPTION
Se agrega: 
- Habilitación persistente del IP forwarding
- Limpieza y despliegue de reglas nftables
- Carga inmediata de la configuración
- Configuración de servidores DNS
- Adición de rutas estáticas en tiempo de ejecución
- Persistencia de rutas en /etc/network/interfaces
- Plantilla nftables.conf.j2 para gestión de reglas