### PR TITLE
feat(routers): agregar configuración completa para routers 10_20 y 20_30

### DIFF
--- a/config/roles/router_10_20/handlers/main.yml
+++ b/config/roles/router_10_20/handlers/main.yml
@@ -1,0 +1,4 @@
+---
+- name: reload nftables
+  ansible.builtin.command: nft -f /etc/nftables.conf
+  changed_when: true

--- a/config/roles/router_10_20/tasks/main.yml
+++ b/config/roles/router_10_20/tasks/main.yml
@@ -1,0 +1,91 @@
+---
+- name: Habilitar el reenvío de IP (en tiempo de ejecución)
+  ansible.posix.sysctl:
+    name: net.ipv4.ip_forward
+    value: '1'
+    state: present
+    sysctl_set: yes
+    reload: yes
+
+- name: Asegurar que el reenvío de IP sea persistente
+  ansible.posix.sysctl:
+    name: net.ipv4.ip_forward
+    value: '1'
+    state: present
+    sysctl_file: /etc/sysctl.conf
+    reload: yes
+
+- name: Deshabilitar rp_filter para todas las interfaces (en tiempo de ejecución)
+  ansible.posix.sysctl:
+    name: "net.ipv4.conf.{{ item }}.rp_filter"
+    value: '0'
+    state: present
+    sysctl_set: yes
+    reload: yes
+  loop: "{{ interfaces }}"
+
+- name: Asegurar que rp_filter sea persistente
+  ansible.posix.sysctl:
+    name: "net.ipv4.conf.{{ item }}.rp_filter"
+    value: '0'
+    state: present
+    sysctl_file: /etc/sysctl.conf
+    reload: yes
+  loop: "{{ interfaces }}"
+
+- name: Vaciar las reglas existentes de nftables
+  ansible.builtin.command: nft flush ruleset
+  changed_when: true
+  failed_when: false
+
+- name: Desplegar la configuración de nftables
+  ansible.builtin.template:
+    src: nftables.conf.j2
+    dest: /etc/nftables.conf
+    owner: root
+    group: root
+    mode: '0644'
+  notify: reload nftables
+
+- name: Cargar las reglas de nftables inmediatamente
+  ansible.builtin.command: nft -f /etc/nftables.conf
+  changed_when: true
+
+- name: Agregar ruta por defecto hacia el NAT Gateway (en tiempo de ejecución)
+  ansible.builtin.command:
+    cmd: "ip route add default via {{ nat_gateway_ip }} dev {{ nat_gateway_interface }}"
+  register: default_route_result
+  failed_when: default_route_result.rc != 0 and 'File exists' not in default_route_result.stderr
+  changed_when: default_route_result.rc == 0
+
+- name: Agregar ruta estática hacia VLAN30 (en tiempo de ejecución)
+  ansible.builtin.command:
+    cmd: "ip route add {{ vlan30_network }} via {{ vlan30_gateway }} dev {{ vlan30_interface }}"
+  register: vlan30_route_result
+  failed_when: vlan30_route_result.rc != 0 and 'File exists' not in vlan30_route_result.stderr
+  changed_when: vlan30_route_result.rc == 0
+
+- name: Asegurar que la ruta estática hacia VLAN30 sea persistente
+  ansible.builtin.blockinfile:
+    path: /etc/network/interfaces
+    block: |
+      # Ruta estática hacia VLAN30 (a través del router-20-30)
+      up ip route add {{ vlan30_network }} via {{ vlan30_gateway }} dev {{ vlan30_interface }}
+    marker: "# {mark} ANSIBLE MANAGED VLAN30 ROUTE"
+    create: yes
+    mode: '0644'
+
+- name: Configurar los servidores DNS en resolv.conf
+  ansible.builtin.copy:
+    dest: /etc/resolv.conf
+    content: |
+      {% for dns in dns_servers %}
+      nameserver {{ dns }}
+      {% endfor %}
+    owner: root
+    group: root
+    mode: '0644'
+
+- name: Mostrar mensaje de finalización
+  ansible.builtin.debug:
+    msg: "Configuración del Router 10_20 completada en {{ inventory_hostname }}"

--- a/config/roles/router_10_20/templates/nftables.conf.j2
+++ b/config/roles/router_10_20/templates/nftables.conf.j2
@@ -1,0 +1,25 @@
+table inet filter {
+    chain input {
+        type filter hook input priority 0;
+        policy drop;
+
+        # Allow loopback and established traffic
+        iifname "lo" accept;
+        ct state established,related accept;
+
+        # Allow SSH and ICMP
+        tcp dport 22 accept;
+        ip protocol icmp accept;
+    }
+
+    chain forward {
+        type filter hook forward priority 0;
+        policy accept;
+        # Allows routing between VLAN10 ↔ VLAN20 freely
+    }
+
+    chain output {
+        type filter hook output priority 0;
+        policy accept;
+    }
+}

--- a/config/roles/router_10_20/vars/main.yml
+++ b/config/roles/router_10_20/vars/main.yml
@@ -1,0 +1,18 @@
+---
+interfaces:
+  - all
+  - default
+  - eth0
+  - eth1
+
+nat_gateway_ip: 10.10.0.100
+nat_gateway_interface: eth0
+
+vlan30_network: 10.30.0.0/24
+vlan30_gateway: 10.20.0.253
+vlan30_interface: eth1
+
+dns_servers:
+  - 1.1.1.1
+  - 9.9.9.9
+  - 208.67.222.222

--- a/config/roles/router_20_30/handlers/main.yml
+++ b/config/roles/router_20_30/handlers/main.yml
@@ -1,0 +1,4 @@
+---
+- name: reload nftables
+  ansible.builtin.command: nft -f /etc/nftables.conf
+  changed_when: true

--- a/config/roles/router_20_30/tasks/main.yml
+++ b/config/roles/router_20_30/tasks/main.yml
@@ -1,0 +1,74 @@
+---
+- name: Habilitar el reenvío de IP (en tiempo de ejecución)
+  ansible.posix.sysctl:
+    name: net.ipv4.ip_forward
+    value: '1'
+    state: present
+    sysctl_set: yes
+    reload: yes
+
+- name: Asegurar que el reenvío de IP sea persistente
+  ansible.posix.sysctl:
+    name: net.ipv4.ip_forward
+    value: '1'
+    state: present
+    sysctl_file: /etc/sysctl.conf
+    reload: yes
+
+- name: Deshabilitar rp_filter para todas las interfaces (en tiempo de ejecución)
+  ansible.posix.sysctl:
+    name: "net.ipv4.conf.{{ item }}.rp_filter"
+    value: '0'
+    state: present
+    sysctl_set: yes
+    reload: yes
+  loop: "{{ interfaces }}"
+
+- name: Asegurar que rp_filter sea persistente
+  ansible.posix.sysctl:
+    name: "net.ipv4.conf.{{ item }}.rp_filter"
+    value: '0'
+    state: present
+    sysctl_file: /etc/sysctl.conf
+    reload: yes
+  loop: "{{ interfaces }}"
+
+- name: Vaciar las reglas existentes de nftables
+  ansible.builtin.command: nft flush ruleset
+  changed_when: true
+  failed_when: false
+
+- name: Desplegar la configuración de nftables
+  ansible.builtin.template:
+    src: nftables.conf.j2
+    dest: /etc/nftables.conf
+    owner: root
+    group: root
+    mode: '0644'
+  notify: reload nftables
+
+- name: Cargar las reglas de nftables inmediatamente
+  ansible.builtin.command: nft -f /etc/nftables.conf
+  changed_when: true
+
+- name: Agregar ruta por defecto hacia el Router 10_20 (en tiempo de ejecución)
+  ansible.builtin.command:
+    cmd: "ip route add default via {{ upstream_router_ip }} dev {{ upstream_interface }}"
+  register: default_route_result
+  failed_when: default_route_result.rc != 0 and 'File exists' not in default_route_result.stderr
+  changed_when: default_route_result.rc == 0
+
+- name: Configurar los servidores DNS en resolv.conf
+  ansible.builtin.copy:
+    dest: /etc/resolv.conf
+    content: |
+      {% for dns in dns_servers %}
+      nameserver {{ dns }}
+      {% endfor %}
+    owner: root
+    group: root
+    mode: '0644'
+
+- name: Mostrar mensaje de finalización
+  ansible.builtin.debug:
+    msg: "Configuración del Router 20_30 completada en {{ inventory_hostname }}"

--- a/config/roles/router_20_30/templates/nftables.conf.j2
+++ b/config/roles/router_20_30/templates/nftables.conf.j2
@@ -1,0 +1,25 @@
+table inet filter {
+    chain input {
+        type filter hook input priority 0;
+        policy drop;
+
+        # Allow loopback and established connections
+        iifname "lo" accept;
+        ct state established,related accept;
+
+        # Allow SSH and ICMP
+        tcp dport 22 accept;
+        ip protocol icmp accept;
+    }
+
+    chain forward {
+        type filter hook forward priority 0;
+        policy accept;
+        # Allow bidirectional routing between VLAN20 <-> VLAN30
+    }
+
+    chain output {
+        type filter hook output priority 0;
+        policy accept;
+    }
+}

--- a/config/roles/router_20_30/vars/main.yml
+++ b/config/roles/router_20_30/vars/main.yml
@@ -1,0 +1,14 @@
+---
+interfaces:
+  - all
+  - default
+  - eth0
+  - eth1
+
+upstream_router_ip: 10.20.0.254
+upstream_interface: eth0
+
+dns_servers:
+  - 1.1.1.1
+  - 9.9.9.9
+  - 208.67.222.222


### PR DESCRIPTION
Se incluye:
- Habilitación persistente del reenvío de IP (IP forwarding)
- Deshabilitación de rp_filter en todas las interfaces
- Limpieza de reglas nftables existentes
- Despliegue de nuevas reglas mediante plantilla nftables.conf.j2
- Carga inmediata de reglas nftables
- Agregado de rutas por defecto hacia los routers upstream
- Configuración persistente de rutas estáticas cuando corresponde
- Configuración de servidores DNS en resolv.conf
- Mensajes de finalización para control del despliegue
