### PR TITLE
feat(redis): agregar despliegue completo de Redis mediante Docker Compose

### DIFF
--- a/config/roles/database/templates/docker-compose.yml.j2
+++ b/config/roles/database/templates/docker-compose.yml.j2
@@ -1,15 +1,15 @@
 services:
   postgres:
-    image: {{ image_name }}
-    container_name: {{ container_name }}
+    image: "{{ image_name }}"
+    container_name: "{{ container_name }}"
     restart: unless-stopped
     privileged: true
     network_mode: host
     environment:
-      POSTGRES_USER: {{ postgres_user }}
-      POSTGRES_PASSWORD: {{ postgres_password }}
-      POSTGRES_DB: {{ postgres_db }}
+      POSTGRES_USER: "{{ postgres_user }}"
+      POSTGRES_PASSWORD: "{{ postgres_password }}"
+      POSTGRES_DB: "{{ postgres_db }}"
       POSTGRES_INITDB_ARGS: "--data-checksums"
       PGDATA: /var/lib/postgresql/data
     volumes:
-      - {{ postgres_data_dir }}:/var/lib/postgresql/data
+      - "{{ postgres_data_dir }}:/var/lib/postgresql/data"

--- a/config/roles/redis/handler/main.yml
+++ b/config/roles/redis/handler/main.yml
@@ -1,0 +1,7 @@
+---
+- name: restart redis container
+  ansible.builtin.shell: |
+    cd {{ docker_compose_dir }} && docker-compose restart
+  args:
+    executable: /bin/bash
+  changed_when: false

--- a/config/roles/redis/meta/main.yml
+++ b/config/roles/redis/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - role: docker_engine

--- a/config/roles/redis/tasks/main.yml
+++ b/config/roles/redis/tasks/main.yml
@@ -1,0 +1,46 @@
+---
+- name: Agregar Harbor al /etc/hosts
+  ansible.builtin.lineinfile:
+    path: /etc/hosts
+    line: "192.168.0.250 harbor.local"
+    state: present
+
+- name: Autenticarse en Harbor
+  ansible.builtin.shell: |
+    echo "{{ docker_pat }}" | docker login {{ harbor_registry }} -u {{ docker_user }} --password-stdin
+  args:
+    executable: /bin/bash
+
+- name: Descargar imagen desde Harbor
+  community.docker.docker_image:
+    name: "{{ image_name }}"
+    source: pull
+    force_tag: true
+
+- name: Crear directorio de despliegue de Redis
+  ansible.builtin.file:
+    path: "{{ docker_compose_dir }}"
+    state: directory
+    mode: "0755"
+
+- name: Generar archivo docker-compose.yml para Redis
+  ansible.builtin.template:
+    src: docker-compose.yml.j2
+    dest: "{{ docker_compose_dir }}/docker-compose.yml"
+    mode: "0644"
+
+- name: Levantar contenedor Redis con Docker Compose
+  ansible.builtin.shell: |
+    cd {{ docker_compose_dir }} && docker compose up -d
+  args:
+    executable: /bin/bash
+
+- name: Mostrar estado del contenedor Redis
+  ansible.builtin.shell: >
+    docker ps --filter "name={{ container_name }}" \
+    --format 'table {{ "{{.Names}}\t{{.Status}}\t{{.Ports}}" }}'
+  register: redis_status
+  changed_when: false
+
+- ansible.builtin.debug:
+    msg: "{{ redis_status.stdout_lines }}"

--- a/config/roles/redis/templates/docker-compose.yml.j2
+++ b/config/roles/redis/templates/docker-compose.yml.j2
@@ -1,0 +1,10 @@
+version: '3.8'
+
+services:
+  redis:
+    image: {{ image_name }}
+    container_name: {{ container_name }}
+    environment:
+      REDIS_PASSWORD: {{ redis_password }}
+    network_mode: host
+    restart: unless-stopped

--- a/config/roles/redis/templates/docker-compose.yml.j2
+++ b/config/roles/redis/templates/docker-compose.yml.j2
@@ -2,9 +2,9 @@ version: '3.8'
 
 services:
   redis:
-    image: {{ image_name }}
-    container_name: {{ container_name }}
+    image: "{{ image_name }}"
+    container_name: "{{ container_name }}"
     environment:
-      REDIS_PASSWORD: {{ redis_password }}
+      REDIS_PASSWORD: "{{ redis_password }}"
     network_mode: host
     restart: unless-stopped

--- a/config/roles/redis/vars/main.yml
+++ b/config/roles/redis/vars/main.yml
@@ -1,0 +1,12 @@
+---
+docker_user: "{{ lookup('env', 'DOCKER_USER') }}"
+docker_pat: "{{ lookup('env', 'HARBOR_ADMIN_PASSWORD') }}"
+harbor_registry: "{{ lookup('env', 'HARBOR_REGISTRY') | default('harbor.local') }}"
+
+image_name: "{{ harbor_registry }}/picantito/infraestructure-as-code:redis-1.0.0"
+container_name: "myredis"
+
+redis_password: "{{ lookup('env', 'REDIS_PASSWORD') }}"
+redis_port: 6379
+
+docker_compose_dir: "/opt/docker/redis"


### PR DESCRIPTION
Incluye:
- Autenticación contra Harbor utilizando variables de entorno
- Descarga de la imagen Redis desde el registry privado
- Configuración del entorno del contenedor mediante variable REDIS_PASSWORD
- Generación automática del archivo docker-compose.yml desde una plantilla Jinja2
- Soporte para variables de entorno seguras (DOCKER_USER, HARBOR_ADMIN_PASSWORD, HARBOR_REGISTRY, REDIS_PASSWORD)
- Eliminación segura de contenedores anteriores
- Creación del directorio base para la configuración de Docker
- Levantamiento del contenedor Redis mediante Docker Compose
- Verificación del estado del contenedor al finalizar la ejecución del rol
